### PR TITLE
feat: Implement %unload_ext

### DIFF
--- a/src/quak/__init__.py
+++ b/src/quak/__init__.py
@@ -6,7 +6,7 @@ from ._widget import Widget
 __all__ = ["Widget", "__version__"]
 
 
-def load_ipython_extension(ipython):  # type: ignore[no-untyped-def]
+def load_ipython_extension(ipython) -> None:  # type: ignore[no-untyped-def]
     """Extend IPython with the interactive quak display for dataframes."""
     import duckdb
     from IPython.core.formatters import DisplayFormatter
@@ -23,3 +23,10 @@ def load_ipython_extension(ipython):  # type: ignore[no-untyped-def]
             return super().format(obj, include, exclude)
 
     ipython.display_formatter = QuakDisplayFormatter()
+
+
+def unload_ipython_extension(ipython) -> None:  # type: ignore[no-untyped-def]
+    """Unload the quak extension from IPython."""
+    from IPython.core.formatters import DisplayFormatter
+
+    ipython.display_formatter = DisplayFormatter()


### PR DESCRIPTION
Fixes #22

We could maybe try to capture the original display hook and restore it, but this is much more simple.
