### PR TITLE
Add hovered value label for Histogram plot

### DIFF
--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -84,6 +84,7 @@ export function CrossfilterHistogramPlot(
 		.append("g")
 		.attr("fill", fillColor);
 
+	// Min and max values labels
 	svg
 		.append("g")
 		.attr("transform", `translate(0,${height - marginBottom})`)

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -154,9 +154,7 @@ export function CrossfilterHistogramPlot(
 			.attr("visibility", hovered.value ? "visible" : "hidden")
 			.attr(
 				"transform",
-				`translate(${x(hovered.value || 0) - 5},${
-					height - marginBottom
-				})`,
+				`translate(${x(hovered.value || 0) - 5},${height - marginBottom})`,
 			)
 			.attr("width", bbox.width + 5)
 			.attr("height", bbox.height + 5);

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -229,7 +229,7 @@ export function CrossfilterHistogramPlot(
 		const f = d3.format("~s");
 		hovered.value = f(value);
 	});
-	node.addEventListener("mouseleave", (event) => {
+	node.addEventListener("mouseleave", (_) => {
 		hovered.value = undefined;
 	});
 

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -251,7 +251,7 @@ export function CrossfilterHistogramPlot(
 		const relativeX = event.clientX - node.getBoundingClientRect().left;
 		hovered.value = x.invert(relativeX);
 	});
-	node.addEventListener("mouseleave", (_) => {
+	node.addEventListener("mouseleave", () => {
 		hovered.value = undefined;
 	});
 

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -212,6 +212,18 @@ export function CrossfilterHistogramPlot(
 	let node = svg.node();
 	assert(node, "Infallable");
 
+	node.addEventListener("mousemove", (event) => {
+		console.log("mouseover on Histogram!");
+		const relativeX = event.clientX - node.getBoundingClientRect().left;
+		const value = x.invert(relativeX);
+		// const f = d3.format(".1f"); // TODO: There needs to be a better way to decide format
+		const f = d3.format("~s");
+		hoveredValue = f(value);
+		console.log(value);
+		console.log("hoveredValue: " + hoveredValue);
+		// render(bins, nullCount);
+	});
+
 	render(bins, nullCount);
 	return Object.assign(node, {
 		/** @param {string} type */

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -105,12 +105,11 @@ export function CrossfilterHistogramPlot(
 		});
 
 	//~ Background rect for the next section (hover label)
-	svg.insert("rect")
+	const hoverLabelBackground = svg.insert("rect")
 		.attr("transform", `translate(0,${height - marginBottom})`)
 		.attr("width", 20)
 		.attr("height", 20)
-		.style("fill", "white")
-		.attr("class", "hovered-bg");
+		.style("fill", "white");
 
 	// Value under cursor label
 	const hoveredTick = svg
@@ -149,8 +148,7 @@ export function CrossfilterHistogramPlot(
 			.node() as SVGGraphicsElement;
 		const bbox = hoveredTickText.getBBox();
 
-		svg
-			.selectAll(".hovered-bg")
+		hoverLabelBackground
 			.attr("visibility", hovered.value ? "visible" : "hidden")
 			.attr(
 				"transform",

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -1,5 +1,5 @@
-import * as d3 from "../deps/d3.ts";
 import { effect, signal } from "@preact/signals-core";
+import * as d3 from "../deps/d3.ts";
 import { assert } from "../utils/assert.ts";
 import { tickFormatterForBins } from "./tick-formatter-for-bins.ts";
 import type { Bin, Scale } from "../types.ts";

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -134,7 +134,8 @@ export function CrossfilterHistogramPlot(
 
 	// `hovered` signal gets updated in mousemove event
 	effect(() => {
-		const fmt = d3.format("~s");
+		// const fmt = d3.format("~s");
+		const fmt = tickFormatterForBins(type, bins);
 		hoveredTick.selectAll(".tick")
 			.attr("transform", `translate(${x(hovered.value)},0)`)
 			.attr("visibility", hovered.value ? "visible" : "hidden");

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -43,7 +43,7 @@ export function CrossfilterHistogramPlot(
 	scale: (type: string) => Scale<number, number>;
 	update(bins: Array<Bin>, opts: { nullCount: number }): void;
 } {
-	let hovered = signal<number | undefined>(undefined);
+	let hovered = signal<number | Date | undefined>(undefined);
 	let nullBinWidth = nullCount === 0 ? 0 : 5;
 	let spacing = nullBinWidth ? 4 : 0;
 	let extent = /** @type {const} */ ([
@@ -137,23 +137,26 @@ export function CrossfilterHistogramPlot(
 		// const fmt = d3.format("~s");
 		const fmt = tickFormatterForBins(type, bins);
 		hoveredTick.selectAll(".tick")
-			.attr("transform", `translate(${x(hovered.value)},0)`)
+			.attr("transform", `translate(${x(hovered.value || 0)},0)`)
 			.attr("visibility", hovered.value ? "visible" : "hidden");
 
 		hoveredTick
 			.selectAll(".tick text")
-			.text(`${fmt(hovered.value)}`)
+			.text(`${fmt(hovered.value || 0)}`)
 			.attr("visibility", hovered.value ? "visible" : "hidden");
 
-		const hoveredTickText = hoveredTick.select(".tick text");
-		const bbox = hoveredTickText.node().getBBox();
+		const hoveredTickText = hoveredTick.select(".tick text")
+			.node() as SVGGraphicsElement;
+		const bbox = hoveredTickText.getBBox();
 
 		svg
 			.selectAll(".hovered-bg")
 			.attr("visibility", hovered.value ? "visible" : "hidden")
 			.attr(
 				"transform",
-				`translate(${x(hovered.value) - 5},${height - marginBottom})`,
+				`translate(${x(hovered.value || 0) - 5},${
+					height - marginBottom
+				})`,
 			)
 			.attr("width", bbox.width + 5)
 			.attr("height", bbox.height + 5);

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -42,6 +42,7 @@ export function CrossfilterHistogramPlot(
 	scale: (type: string) => Scale<number, number>;
 	update(bins: Array<Bin>, opts: { nullCount: number }): void;
 } {
+	let hoveredValue: number | undefined = 100;
 	let nullBinWidth = nullCount === 0 ? 0 : 5;
 	let spacing = nullBinWidth ? 4 : 0;
 	let extent = /** @type {const} */ ([
@@ -100,6 +101,28 @@ export function CrossfilterHistogramPlot(
 				.attr("text-anchor", (_, i) => i === 0 ? "start" : "end")
 				.attr("dx", (_, i) => i === 0 ? "-0.25em" : "0.25em");
 		});
+
+	// Value under cursor label
+	if (hoveredValue) {
+		svg
+			.append("g")
+			.attr("transform", `translate(0,${height - marginBottom})`)
+			.call(
+				d3
+					.axisBottom(x)
+					// .tickValues(x.domain())
+					.tickValues([hoveredValue])
+					.tickFormat(tickFormatterForBins(type, bins))
+					.tickSize(2.5),
+			)
+			.call((g) => {
+				g.select(".domain").remove();
+				g.attr("class", "gray");
+				g.selectAll(".tick text")
+					.attr("text-anchor", (_, i) => i === 0 ? "start" : "end")
+					.attr("dx", (_, i) => i === 0 ? "-0.25em" : "0.25em");
+			});
+	}
 
 	/** @type {typeof foregroundBarGroup | undefined} */
 	let foregroundNullGroup: typeof foregroundBarGroup | undefined = undefined;

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -104,6 +104,14 @@ export function CrossfilterHistogramPlot(
 				.attr("dx", (_, i) => i === 0 ? "-0.25em" : "0.25em");
 		});
 
+	//~ Background rect for the next section (hover label)
+	svg.insert("rect")
+		.attr("transform", `translate(0,${height - marginBottom})`)
+		.attr("width", 20)
+		.attr("height", 20)
+		.style("fill", "white")
+		.attr("class", "hovered-bg");
+
 	// Value under cursor label
 	const hoveredTick = svg
 		.append("g")
@@ -134,6 +142,19 @@ export function CrossfilterHistogramPlot(
 			.selectAll(".tick text")
 			.text(`${hovered.value}`)
 			.attr("visibility", hovered.value ? "visible" : "hidden");
+
+		const hoveredTickText = hoveredTick.select(".tick text");
+		const bbox = hoveredTickText.node().getBBox();
+
+		svg
+			.selectAll(".hovered-bg")
+			.attr("visibility", hovered.value ? "visible" : "hidden")
+			.attr(
+				"transform",
+				`translate(${x(hovered.value) - 5},${height - marginBottom})`,
+			)
+			.attr("width", bbox.width + 5)
+			.attr("height", bbox.height + 5);
 	});
 
 	/** @type {typeof foregroundBarGroup | undefined} */

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -134,13 +134,14 @@ export function CrossfilterHistogramPlot(
 
 	// `hovered` signal gets updated in mousemove event
 	effect(() => {
+		const fmt = d3.format("~s");
 		hoveredTick.selectAll(".tick")
 			.attr("transform", `translate(${x(hovered.value)},0)`)
 			.attr("visibility", hovered.value ? "visible" : "hidden");
 
 		hoveredTick
 			.selectAll(".tick text")
-			.text(`${hovered.value}`)
+			.text(`${fmt(hovered.value)}`)
 			.attr("visibility", hovered.value ? "visible" : "hidden");
 
 		const hoveredTickText = hoveredTick.select(".tick text");
@@ -247,8 +248,7 @@ export function CrossfilterHistogramPlot(
 	node.addEventListener("mousemove", (event) => {
 		const relativeX = event.clientX - node.getBoundingClientRect().left;
 		const value = x.invert(relativeX);
-		const f = d3.format("~s");
-		hovered.value = f(value);
+		hovered.value = value;
 	});
 	node.addEventListener("mouseleave", (_) => {
 		hovered.value = undefined;

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -133,7 +133,6 @@ export function CrossfilterHistogramPlot(
 
 	// `hovered` signal gets updated in mousemove event
 	effect(() => {
-		// const fmt = d3.format("~s");
 		const fmt = tickFormatterForBins(type, bins);
 		hoveredTick.selectAll(".tick")
 			.attr("transform", `translate(${x(hovered.value || 0)},0)`)

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -120,16 +120,20 @@ export function CrossfilterHistogramPlot(
 			g.attr("class", "gray");
 			g.selectAll(".tick text")
 				.attr("text-anchor", (_, i) => i === 0 ? "start" : "end")
-				.attr("dx", (_, i) => i === 0 ? "-0.25em" : "0.25em");
+				.attr("dx", (_, i) => i === 0 ? "-0.25em" : "0.25em")
+				.attr("visibility", "hidden");
 		});
 
+	// `hovered` signal gets updated in mousemove event
 	effect(() => {
 		hoveredTick.selectAll(".tick")
-			.attr("transform", `translate(${x(hovered.value)},0)`);
+			.attr("transform", `translate(${x(hovered.value)},0)`)
+			.attr("visibility", hovered.value ? "visible" : "hidden");
 
 		hoveredTick
 			.selectAll(".tick text")
-			.text(`${hovered.value}`);
+			.text(`${hovered.value}`)
+			.attr("visibility", hovered.value ? "visible" : "hidden");
 	});
 
 	/** @type {typeof foregroundBarGroup | undefined} */
@@ -224,6 +228,9 @@ export function CrossfilterHistogramPlot(
 		const value = x.invert(relativeX);
 		const f = d3.format("~s");
 		hovered.value = f(value);
+	});
+	node.addEventListener("mouseleave", (event) => {
+		hovered.value = undefined;
 	});
 
 	render(bins, nullCount);

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -247,8 +247,7 @@ export function CrossfilterHistogramPlot(
 
 	node.addEventListener("mousemove", (event) => {
 		const relativeX = event.clientX - node.getBoundingClientRect().left;
-		const value = x.invert(relativeX);
-		hovered.value = value;
+		hovered.value = x.invert(relativeX);
 	});
 	node.addEventListener("mouseleave", (_) => {
 		hovered.value = undefined;


### PR DESCRIPTION
The ValueCounts plot shows what the user is hovering before making a selection. This is a quick implementation of a similar behavior for the histogram.

![hover](https://github.com/user-attachments/assets/e2bdfd86-7d09-4d09-ae7b-d7341fb0a77a)

There's a bunch of stuff that could be improved: (I might give it a try before closing this PR)
- [ ]  Give the label a background to prevent collision with the min/max tick labels
    - AFAIK, since the labels are done through an SVG, you need to implement this through a rect that matches the text's bounding box
- [ ] label following the cursor during selection dragging
    - also bit complicated due to the events captured by mosaic interactor
- [ ] better value formatting