### PR TITLE
fix: Temp cast Arrow string_view to string until next DuckDB release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev-dependencies = [
     "jupyterlab>=4.2.2",
     "watchfiles>=0.22.0",
     "vega-datasets>=0.9.0",
+    "polars>=1.4.1",
 ]
 
 [tool.ruff.lint]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -170,6 +170,7 @@ pexpect==4.9.0
     # via ipython
 platformdirs==4.2.2
     # via jupyter-core
+polars==1.4.1
 prometheus-client==0.20.0
     # via jupyter-server
 prompt-toolkit==3.0.47

--- a/src/quak/_util.py
+++ b/src/quak/_util.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import sys
 import typing
 
 DataFrameObject = typing.Any
 
 if typing.TYPE_CHECKING:
     import duckdb
+    import polars as pl
     import pyarrow as pa
 
 
@@ -98,12 +100,7 @@ def get_columns(conn: duckdb.DuckDBPyConnection, table_name: str) -> list[str]:
     return [row[0] for row in rows]
 
 
-def ensure_duckdb_compatable_pyarrow_table(table: pa.lib.Table):
-    """Mutates a pyarrow table to be compatible with DuckDB."""
-    import pyarrow as pa
-    import pyarrow.compute as pc
-
-    for i, name in enumerate(table.column_names):
-        column = table[name]
-        if pa.types.is_string_view(column.type):
-            table.set_column(i, name, pc.cast(column, pa.string()))
+def is_polars(obj: object) -> typing.TypeGuard[pl.DataFrame]:
+    """Check if an object is a Polars DataFrame."""
+    polars = sys.modules.get("polars")
+    return polars is not None and isinstance(obj, polars.DataFrame)

--- a/src/quak/_util.py
+++ b/src/quak/_util.py
@@ -96,3 +96,14 @@ def get_columns(conn: duckdb.DuckDBPyConnection, table_name: str) -> list[str]:
     """)
     rows = result.fetchall()
     return [row[0] for row in rows]
+
+
+def ensure_duckdb_compatable_pyarrow_table(table: pa.lib.Table):
+    """Mutates a pyarrow table to be compatible with DuckDB."""
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    for i, name in enumerate(table.column_names):
+        column = table[name]
+        if pa.types.is_string_view(column.type):
+            table.set_column(i, name, pc.cast(column, pa.string()))

--- a/src/quak/_widget.py
+++ b/src/quak/_widget.py
@@ -12,6 +12,7 @@ import traitlets
 from ._util import (
     arrow_table_from_dataframe_protocol,
     arrow_table_from_ipc,
+    ensure_duckdb_compatable_pyarrow_table,
     get_columns,
     has_pycapsule_stream_interface,
     is_arrow_ipc,
@@ -47,6 +48,7 @@ class Widget(anywidget.AnyWidget):
                 # create a new DuckDB table from the stream.
                 # arrow_table = pa.RecordBatchReader.from_stream(data)
                 arrow_table = pa.table(data)
+                ensure_duckdb_compatable_pyarrow_table(arrow_table)
             elif is_arrow_ipc(data):
                 arrow_table = arrow_table_from_ipc(data)
             elif is_dataframe_api_obj(data):
@@ -94,9 +96,9 @@ class Widget(anywidget.AnyWidget):
 
         total = round((time.time() - start) * 1_000)
         if total > SLOW_QUERY_THRESHOLD:
-            logger.warning(f"DONE. Slow query { uuid } took { total } ms.\n{ sql }")
+            logger.warning(f"DONE. Slow query {uuid} took {total} ms.\n{sql}")
         else:
-            logger.info(f"DONE. Query { uuid } took { total } ms.\n{ sql }")
+            logger.info(f"DONE. Query {uuid} took {total} ms.\n{sql}")
 
     def data(self) -> duckdb.DuckDBPyRelation:
         """Return the current SQL as a DuckDB relation."""


### PR DESCRIPTION
Towards #41 

~Right now I'm running into an issue with pyarrow where the casting isn't working:~


Temporarily special case polars data frames to use `to_arrow()` which casts to non-view datatypes. IN the future, DuckDB should support view data types and we will prefer the pycapsule interface.