### PR TITLE
feat: Show category counts/percentages on ValueCounts hover

### DIFF
--- a/lib/clients/DataTable.ts
+++ b/lib/clients/DataTable.ts
@@ -265,7 +265,7 @@ export class DataTable extends MosaicClient {
 			} else {
 				vis = new ValueCounts({
 					table: this.#meta.table,
-					column: field.name,
+					field: field,
 					filterBy: this.filterBy!,
 				});
 			}

--- a/lib/clients/ValueCounts.ts
+++ b/lib/clients/ValueCounts.ts
@@ -18,8 +18,8 @@ import { assert } from "../utils/assert.ts";
 interface UniqueValuesOptions {
 	/** The table to query. */
 	table: string;
-	/** The column to use for the histogram. */
-	column: string;
+	/** An arrow Field containing the column info to use for the histogram. */
+	field: arrow.Field;
 	/** A mosaic selection to filter the data. */
 	filterBy: Selection;
 }
@@ -29,13 +29,15 @@ type CountTable = arrow.Table<{ key: arrow.Utf8; total: arrow.Int }>;
 export class ValueCounts extends MosaicClient {
 	#table: string;
 	#column: string;
+	#field: arrow.Field;
 	#el: HTMLElement = document.createElement("div");
 	#plot: ReturnType<typeof ValueCountsPlot> | undefined;
 
 	constructor(options: UniqueValuesOptions) {
 		super(options.filterBy);
 		this.#table = options.table;
-		this.#column = options.column;
+		this.#column = options.field.name;
+		this.#field = options.field;
 
 		// FIXME: There is some issue with the mosaic client or the query we
 		// are using here. Updates to the Selection (`filterBy`) seem to be
@@ -55,8 +57,7 @@ export class ValueCounts extends MosaicClient {
 	}
 
 	query(filter: Array<SQLExpression> = []): Query {
-		let counts = Query
-			.from({ source: this.#table })
+		let counts = Query.from({ source: this.#table })
 			.select({
 				value: sql`CASE
 					WHEN ${column(this.#column)} IS NULL THEN '__quak_null__'
@@ -66,24 +67,21 @@ export class ValueCounts extends MosaicClient {
 			})
 			.groupby("value")
 			.where(filter);
-		return Query
-			.with({ counts })
-			.select(
-				{
-					key: sql`CASE
+		return Query.with({ counts })
+			.select({
+				key: sql`CASE
 						WHEN "count" = 1 AND "value" != '__quak_null__' THEN '__quak_unique__'
 						ELSE "value"
 					END`,
-					total: sum("count"),
-				},
-			)
+				total: sum("count"),
+			})
 			.from("counts")
 			.groupby("key");
 	}
 
 	queryResult(data: CountTable): this {
 		if (!this.#plot) {
-			let plot = this.#plot = ValueCountsPlot(data);
+			let plot = (this.#plot = ValueCountsPlot(data, this.#field));
 			this.#el.appendChild(plot);
 			effect(() => {
 				let clause = this.clause(plot.selected.value);

--- a/lib/clients/ValueCounts.ts
+++ b/lib/clients/ValueCounts.ts
@@ -57,7 +57,8 @@ export class ValueCounts extends MosaicClient {
 	}
 
 	query(filter: Array<SQLExpression> = []): Query {
-		let counts = Query.from({ source: this.#table })
+		let counts = Query
+			.from({ source: this.#table })
 			.select({
 				value: sql`CASE
 					WHEN ${column(this.#column)} IS NULL THEN '__quak_null__'
@@ -67,14 +68,17 @@ export class ValueCounts extends MosaicClient {
 			})
 			.groupby("value")
 			.where(filter);
-		return Query.with({ counts })
-			.select({
-				key: sql`CASE
+		return Query
+			.with({ counts })
+			.select(
+				{
+					key: sql`CASE
 						WHEN "count" = 1 AND "value" != '__quak_null__' THEN '__quak_unique__'
 						ELSE "value"
 					END`,
-				total: sum("count"),
-			})
+					total: sum("count"),
+				},
+			)
 			.from("counts")
 			.groupby("key");
 	}

--- a/lib/utils/ValueCountsPlot.ts
+++ b/lib/utils/ValueCountsPlot.ts
@@ -182,8 +182,8 @@ function prepareData(data: CountTableData) {
 		.toSorted((a, b) => b.total - a.total);
 	let total = arr.reduce((acc, d) => acc + d.total, 0);
 	return {
-		bins: arr.filter(
-			(d) => d.key !== "__quak_null__" && d.key !== "__quak_unique__",
+		bins: arr.filter((d) =>
+			d.key !== "__quak_null__" && d.key !== "__quak_unique__"
 		),
 		nullCount: arr.find((d) => d.key === "__quak_null__")?.total ?? 0,
 		uniqueCount: arr.find((d) => d.key === "__quak_unique__")?.total ?? 0,
@@ -193,21 +193,17 @@ function prepareData(data: CountTableData) {
 
 type Entry = { key: string; total: number };
 
-function createBars(
-	data: CountTableData,
-	opts: {
-		width: number;
-		height: number;
-		marginRight: number;
-		marginLeft: number;
-		fillColor: string;
-		backgroundBarColor: string;
-		nullFillColor: string;
-	},
-) {
+function createBars(data: CountTableData, opts: {
+	width: number;
+	height: number;
+	marginRight: number;
+	marginLeft: number;
+	fillColor: string;
+	backgroundBarColor: string;
+	nullFillColor: string;
+}) {
 	let source = prepareData(data);
-	let x = d3
-		.scaleLinear()
+	let x = d3.scaleLinear()
 		.domain([0, source.total])
 		.range([opts.marginLeft, opts.width - opts.marginRight]);
 
@@ -231,7 +227,10 @@ function createBars(
 	let selectBar = createVirtualSelectionBar(opts);
 	let virtualBar: HTMLElement | undefined;
 	if (source.bins.length > thresh) {
-		let total = source.bins.slice(thresh).reduce((acc, d) => acc + d.total, 0);
+		let total = source.bins.slice(thresh).reduce(
+			(acc, d) => acc + d.total,
+			0,
+		);
 		virtualBar = Object.assign(document.createElement("div"), {
 			title: "__quak_virtual__",
 		});
@@ -270,14 +269,12 @@ function createBars(
 			height: opts.height,
 		});
 		bar.title = "__quak_unique__";
-		bars.push(
-			Object.assign(bar, {
-				data: {
-					key: "__quak_unique__",
-					total: source.uniqueCount,
-				},
-			}),
-		);
+		bars.push(Object.assign(bar, {
+			data: {
+				key: "__quak_unique__",
+				total: source.uniqueCount,
+			},
+		}));
 	}
 
 	if (source.nullCount) {
@@ -289,14 +286,12 @@ function createBars(
 			height: opts.height,
 		});
 		bar.title = "__quak_null__";
-		bars.push(
-			Object.assign(bar, {
-				data: {
-					key: "__quak_null__",
-					total: source.uniqueCount,
-				},
-			}),
-		);
+		bars.push(Object.assign(bar, {
+			data: {
+				key: "__quak_null__",
+				total: source.uniqueCount,
+			},
+		}));
 	}
 
 	let first = bars[0];
@@ -417,7 +412,7 @@ function createBars(
 				if (bar.title === "__quak_virtual__") {
 					let vbars = bar.firstChild as HTMLDivElement;
 					vbars.style.background = createVirtualBarRepeatingBackground({
-						color: total < source.total || selected
+						color: (total < source.total) || selected
 							? opts.backgroundBarColor
 							: opts.fillColor,
 					});
@@ -506,17 +501,13 @@ function nearestX({ clientX }: MouseEvent, bars: Array<HTMLElement>) {
 /**
  * Creates a fill gradient that is filled x% with a color and the rest with a background color.
  */
-function createSplitBarFill(options: {
-	color: string;
-	bgColor: string;
-	frac: number;
-}) {
+function createSplitBarFill(
+	options: { color: string; bgColor: string; frac: number },
+) {
 	let { color, bgColor, frac } = options;
 	let p = frac * 100;
 	// deno-fmt-ignore
-	return `linear-gradient(to top, ${color} ${p}%, ${bgColor} ${p}%, ${bgColor} ${
-    100 - p
-  }%)`;
+	return `linear-gradient(to top, ${color} ${p}%, ${bgColor} ${p}%, ${bgColor} ${100 - p}%)`;
 }
 
 function createVirtualBarRepeatingBackground({ color }: { color: string }) {

--- a/lib/utils/ValueCountsPlot.ts
+++ b/lib/utils/ValueCountsPlot.ts
@@ -2,6 +2,7 @@ import { effect, signal } from "@preact/signals-core";
 import type * as arrow from "apache-arrow";
 import * as d3 from "../deps/d3.ts";
 import { assert } from "./assert.ts";
+import { formatDataType } from "./formatting.ts";
 
 type CountTableData = arrow.Table<{
 	key: arrow.Utf8;
@@ -22,6 +23,7 @@ interface ValueCountsPlot {
 
 export function ValueCountsPlot(
 	data: CountTableData,
+	field: arrow.Field,
 	{
 		width = 125,
 		height = 30,
@@ -33,6 +35,8 @@ export function ValueCountsPlot(
 		backgroundBarColor = "rgb(226, 226, 226)",
 	}: ValueCountsPlot = {},
 ) {
+	const fieldType = formatDataType(field.type);
+
 	let root = document.createElement("div");
 	root.style.position = "relative";
 
@@ -64,6 +68,7 @@ export function ValueCountsPlot(
 	let hovering = signal<string | undefined>(undefined);
 	let selected = signal<string | undefined>(undefined);
 	let counts = signal<CountTableData>(data);
+	let countLabel = signal<string>(fieldType);
 
 	let hitArea = document.createElement("div");
 	Object.assign(hitArea.style, {
@@ -77,9 +82,28 @@ export function ValueCountsPlot(
 	});
 	hitArea.addEventListener("mousemove", (event) => {
 		hovering.value = bars.nearestX(event);
+
+		let update: Record<string, number> = Object.fromEntries(
+			Array.from(data.toArray(), (d) => [d.key, d.total]),
+		);
+
+		let total = Object.values(update).reduce((a, b) => a + b, 0);
+
+		const hoveredValue = hovering.value;
+		const hoveredValueCount = hoveredValue !== undefined
+			? update[hoveredValue]
+			: undefined;
+
+		countLabel.value =
+			hoveredValue !== undefined && hoveredValueCount !== undefined
+				? `${hoveredValueCount} row${hoveredValueCount === 1 ? "" : "s"} (${
+					d3.format(".1%")(hoveredValueCount / total)
+				})`
+				: fieldType;
 	});
 	hitArea.addEventListener("mouseout", () => {
 		hovering.value = undefined;
+		countLabel.value = fieldType;
 	});
 	hitArea.addEventListener("mousedown", (event) => {
 		let next = bars.nearestX(event);
@@ -89,6 +113,13 @@ export function ValueCountsPlot(
 	effect(() => {
 		text.textContent = bars.textFor(hovering.value ?? selected.value);
 		bars.render(counts.value, hovering.value, selected.value);
+
+		const labelElement = root.parentElement?.parentElement?.querySelector(
+			".gray",
+		);
+		if (labelElement) {
+			labelElement.textContent = countLabel.value;
+		}
 	});
 
 	root.appendChild(container);
@@ -151,8 +182,8 @@ function prepareData(data: CountTableData) {
 		.toSorted((a, b) => b.total - a.total);
 	let total = arr.reduce((acc, d) => acc + d.total, 0);
 	return {
-		bins: arr.filter((d) =>
-			d.key !== "__quak_null__" && d.key !== "__quak_unique__"
+		bins: arr.filter(
+			(d) => d.key !== "__quak_null__" && d.key !== "__quak_unique__",
 		),
 		nullCount: arr.find((d) => d.key === "__quak_null__")?.total ?? 0,
 		uniqueCount: arr.find((d) => d.key === "__quak_unique__")?.total ?? 0,
@@ -162,17 +193,21 @@ function prepareData(data: CountTableData) {
 
 type Entry = { key: string; total: number };
 
-function createBars(data: CountTableData, opts: {
-	width: number;
-	height: number;
-	marginRight: number;
-	marginLeft: number;
-	fillColor: string;
-	backgroundBarColor: string;
-	nullFillColor: string;
-}) {
+function createBars(
+	data: CountTableData,
+	opts: {
+		width: number;
+		height: number;
+		marginRight: number;
+		marginLeft: number;
+		fillColor: string;
+		backgroundBarColor: string;
+		nullFillColor: string;
+	},
+) {
 	let source = prepareData(data);
-	let x = d3.scaleLinear()
+	let x = d3
+		.scaleLinear()
 		.domain([0, source.total])
 		.range([opts.marginLeft, opts.width - opts.marginRight]);
 
@@ -196,10 +231,7 @@ function createBars(data: CountTableData, opts: {
 	let selectBar = createVirtualSelectionBar(opts);
 	let virtualBar: HTMLElement | undefined;
 	if (source.bins.length > thresh) {
-		let total = source.bins.slice(thresh).reduce(
-			(acc, d) => acc + d.total,
-			0,
-		);
+		let total = source.bins.slice(thresh).reduce((acc, d) => acc + d.total, 0);
 		virtualBar = Object.assign(document.createElement("div"), {
 			title: "__quak_virtual__",
 		});
@@ -238,12 +270,14 @@ function createBars(data: CountTableData, opts: {
 			height: opts.height,
 		});
 		bar.title = "__quak_unique__";
-		bars.push(Object.assign(bar, {
-			data: {
-				key: "__quak_unique__",
-				total: source.uniqueCount,
-			},
-		}));
+		bars.push(
+			Object.assign(bar, {
+				data: {
+					key: "__quak_unique__",
+					total: source.uniqueCount,
+				},
+			}),
+		);
 	}
 
 	if (source.nullCount) {
@@ -255,12 +289,14 @@ function createBars(data: CountTableData, opts: {
 			height: opts.height,
 		});
 		bar.title = "__quak_null__";
-		bars.push(Object.assign(bar, {
-			data: {
-				key: "__quak_null__",
-				total: source.uniqueCount,
-			},
-		}));
+		bars.push(
+			Object.assign(bar, {
+				data: {
+					key: "__quak_null__",
+					total: source.uniqueCount,
+				},
+			}),
+		);
 	}
 
 	let first = bars[0];
@@ -381,7 +417,7 @@ function createBars(data: CountTableData, opts: {
 				if (bar.title === "__quak_virtual__") {
 					let vbars = bar.firstChild as HTMLDivElement;
 					vbars.style.background = createVirtualBarRepeatingBackground({
-						color: (total < source.total) || selected
+						color: total < source.total || selected
 							? opts.backgroundBarColor
 							: opts.fillColor,
 					});
@@ -470,13 +506,17 @@ function nearestX({ clientX }: MouseEvent, bars: Array<HTMLElement>) {
 /**
  * Creates a fill gradient that is filled x% with a color and the rest with a background color.
  */
-function createSplitBarFill(
-	options: { color: string; bgColor: string; frac: number },
-) {
+function createSplitBarFill(options: {
+	color: string;
+	bgColor: string;
+	frac: number;
+}) {
 	let { color, bgColor, frac } = options;
 	let p = frac * 100;
 	// deno-fmt-ignore
-	return `linear-gradient(to top, ${color} ${p}%, ${bgColor} ${p}%, ${bgColor} ${100 - p}%)`;
+	return `linear-gradient(to top, ${color} ${p}%, ${bgColor} ${p}%, ${bgColor} ${
+    100 - p
+  }%)`;
 }
 
 function createVirtualBarRepeatingBackground({ color }: { color: string }) {


### PR DESCRIPTION
Great project idea!

This PR adds in some UX seen in the [Observable Summary Table](https://observablehq.com/@cmudig/duckdb-data-table-cells), where hovering over values in the `ValueCountsPlot` displays the corresponding row count/percentage (see demo of PR in action in video below).

### Observable Example:


https://github.com/user-attachments/assets/73f44de0-62de-43b2-a06c-966151db08ec




### Quak Example (this PR):


https://github.com/user-attachments/assets/8d95cd3d-d5b0-4f7f-b2ef-828d47b171ad



Two small differences here versus Observable: 

1. I format the percentage via `d3.format(".1%")`, while they appear to use `d3.format(".0%")`.  (A future improvement could use a ternary to check if the percentage is less than 1, if so, format via `d3.format(".1%")` or .2,, otherwise, `d3.format(".0%")`.

2. On `mouseout`, they appear to show the JS data-type, while I show the type provided by the `arrow.Field` (as that's what was displayed by default in `quak`).



Note:
- This PR also brings in some linting/formatting changes, which occurred after running `deno lint` + `deno fmt`.
- This PR only affects the `Value Counts` plots (for categorical data). I can happily add another PR for the histogram as well 😄
