### PR TITLE
feat: Show value counts and highlight bar on histogram hover

### DIFF
--- a/lib/clients/DataTable.ts
+++ b/lib/clients/DataTable.ts
@@ -259,6 +259,7 @@ export class DataTable extends MosaicClient {
 				vis = new Histogram({
 					table: this.#meta.table,
 					column: field.name,
+					field: field,
 					type: info.type,
 					filterBy: this.filterBy!,
 				});

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -52,23 +52,22 @@ export function CrossfilterHistogramPlot(
 	let countLabel = signal<string>(fieldType);
 	let nullBinWidth = nullCount === 0 ? 0 : 5;
 	let spacing = nullBinWidth ? 4 : 0;
-	let extent = /** @type {const} */ [
+	let extent = /** @type {const} */ ([
 		Math.min(...bins.map((d) => d.x0)),
 		Math.max(...bins.map((d) => d.x1)),
-	];
+	]);
 	let x = type === "date" ? d3.scaleUtc() : d3.scaleLinear();
-	x.domain(extent)
+	x
+		.domain(extent)
 		// @ts-expect-error - range is ok with number for both number and time
 		.range([marginLeft + nullBinWidth + spacing, width - marginRight])
 		.nice();
 
-	let y = d3
-		.scaleLinear()
+	let y = d3.scaleLinear()
 		.domain([0, Math.max(nullCount, ...bins.map((d) => d.length))])
 		.range([height - marginBottom, marginTop]);
 
-	let svg = d3
-		.create("svg")
+	let svg = d3.create("svg")
 		.attr("width", width)
 		.attr("height", height)
 		.attr("viewBox", [0, 0, width, height])
@@ -76,8 +75,7 @@ export function CrossfilterHistogramPlot(
 
 	{
 		// background bars with the "total" bins
-		svg
-			.append("g")
+		svg.append("g")
 			.attr("fill", backgroundBarColor)
 			.selectAll("rect")
 			.data(bins)
@@ -89,7 +87,9 @@ export function CrossfilterHistogramPlot(
 	}
 
 	// Foreground bars for the current subset
-	let foregroundBarGroup = svg.append("g").attr("fill", fillColor);
+	let foregroundBarGroup = svg
+			.append("g")
+			.attr("fill", fillColor);
 
 	// Min and max values labels
 	const axes = svg
@@ -136,9 +136,11 @@ export function CrossfilterHistogramPlot(
 			.text(`${fmt(hovered.value ?? xmin)}`)
 			.attr("visibility", hovered.value ? "visible" : "hidden");
 
-		const hoveredTickText = hoveredTick.select("text").node() as SVGTextElement;
+		const hoveredTickText = hoveredTick
+				.select("text")
+				.node() as SVGTextElement;
 		const bbox = hoveredTickText.getBBox();
-		const cond = x(hovered.value ?? xmin) + bbox.width > x(xmax);
+		const cond = (x(hovered.value ?? xmin) + bbox.width) > x(xmax);
 
 		hoveredTickText.setAttribute("text-anchor", cond ? "end" : "start");
 		hoveredTickText.setAttribute("dx", cond ? "-0.25em" : "0.25em");
@@ -160,11 +162,11 @@ export function CrossfilterHistogramPlot(
 	/** @type {typeof foregroundBarGroup | undefined} */
 	let foregroundNullGroup: typeof foregroundBarGroup | undefined = undefined;
 	if (nullCount > 0) {
-		let xnull = d3.scaleLinear().range([marginLeft, marginLeft + nullBinWidth]);
+		let xnull = d3.scaleLinear()
+				.range([marginLeft, marginLeft + nullBinWidth]);
 
 		// background bar for the null bin
-		svg
-			.append("g")
+		svg.append("g")
 			.attr("fill", backgroundBarColor)
 			.append("rect")
 			.attr("x", xnull(0))
@@ -177,20 +179,21 @@ export function CrossfilterHistogramPlot(
 			.attr("fill", nullFillColor)
 			.attr("color", nullFillColor);
 
-		foregroundNullGroup
-			.append("rect")
+		foregroundNullGroup.append("rect")
 			.attr("x", xnull(0))
 			.attr("width", xnull(1) - xnull(0));
 
 		// Append the x-axis and add a null tick
-		let axisGroup = foregroundNullGroup
-			.append("g")
+		let axisGroup = foregroundNullGroup.append("g")
 			.attr("transform", `translate(0,${height - marginBottom})`)
 			.append("g")
 			.attr("transform", `translate(${xnull(0.5)}, 0)`)
 			.attr("class", "tick");
 
-		axisGroup.append("line").attr("stroke", "currentColor").attr("y2", 2.5);
+		axisGroup
+				.append("line")
+				.attr("stroke", "currentColor")
+				.attr("y2", 2.5);
 
 		axisGroup
 			.append("text")
@@ -205,8 +208,7 @@ export function CrossfilterHistogramPlot(
 	}
 
 	// Apply styles for all axis ticks
-	svg
-		.selectAll(".tick")
+	svg.selectAll(".tick")
 		.attr("font-family", "var(--sans-serif)")
 		.attr("font-weight", "normal");
 

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -88,8 +88,8 @@ export function CrossfilterHistogramPlot(
 
 	// Foreground bars for the current subset
 	let foregroundBarGroup = svg
-			.append("g")
-			.attr("fill", fillColor);
+		.append("g")
+		.attr("fill", fillColor);
 
 	// Min and max values labels
 	const axes = svg
@@ -137,8 +137,8 @@ export function CrossfilterHistogramPlot(
 			.attr("visibility", hovered.value ? "visible" : "hidden");
 
 		const hoveredTickText = hoveredTick
-				.select("text")
-				.node() as SVGTextElement;
+			.select("text")
+			.node() as SVGTextElement;
 		const bbox = hoveredTickText.getBBox();
 		const cond = (x(hovered.value ?? xmin) + bbox.width) > x(xmax);
 
@@ -163,7 +163,7 @@ export function CrossfilterHistogramPlot(
 	let foregroundNullGroup: typeof foregroundBarGroup | undefined = undefined;
 	if (nullCount > 0) {
 		let xnull = d3.scaleLinear()
-				.range([marginLeft, marginLeft + nullBinWidth]);
+			.range([marginLeft, marginLeft + nullBinWidth]);
 
 		// background bar for the null bin
 		svg.append("g")
@@ -191,9 +191,9 @@ export function CrossfilterHistogramPlot(
 			.attr("class", "tick");
 
 		axisGroup
-				.append("line")
-				.attr("stroke", "currentColor")
-				.attr("y2", 2.5);
+			.append("line")
+			.attr("stroke", "currentColor")
+			.attr("y2", 2.5);
 
 		axisGroup
 			.append("text")

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -3,6 +3,8 @@ import * as d3 from "../deps/d3.ts";
 import { assert } from "../utils/assert.ts";
 import { tickFormatterForBins } from "./tick-formatter-for-bins.ts";
 import type { Bin, Scale } from "../types.ts";
+import type * as arrow from "apache-arrow";
+import { formatDataType, percentFormatter } from "./formatting.ts";
 
 interface HistogramOptions {
 	type: "number" | "date";
@@ -26,6 +28,7 @@ interface HistogramOptions {
  */
 export function CrossfilterHistogramPlot(
 	bins: Array<Bin>,
+	field: arrow.Field,
 	{
 		type = "number",
 		width = 125,
@@ -43,7 +46,10 @@ export function CrossfilterHistogramPlot(
 	scale: (type: string) => Scale<number, number>;
 	update(bins: Array<Bin>, opts: { nullCount: number }): void;
 } {
+	const fieldType = formatDataType(field.type);
+	const total = bins.reduce((sum, bin) => sum + bin.length, 0);
 	let hovered = signal<number | Date | undefined>(undefined);
+	let countLabel = signal<string>(fieldType);
 	let nullBinWidth = nullCount === 0 ? 0 : 5;
 	let spacing = nullBinWidth ? 4 : 0;
 	let extent = /** @type {const} */ ([
@@ -144,6 +150,14 @@ export function CrossfilterHistogramPlot(
 			.attr("transform", `translate(${(cond ? -bbox.width : 0) - 2.5}, 2.5)`)
 			.attr("width", bbox.width + 5)
 			.attr("height", bbox.height + 5);
+
+		const labelElement = svg.node()?.parentElement?.parentElement
+			?.querySelector(
+				".gray",
+			);
+		if (labelElement) {
+			labelElement.textContent = countLabel.value;
+		}
 	});
 
 	/** @type {typeof foregroundBarGroup | undefined} */
@@ -211,7 +225,8 @@ export function CrossfilterHistogramPlot(
 			.attr("x", (d) => x(d.x0) + 1.5)
 			.attr("width", (d) => x(d.x1) - x(d.x0) - 1.5)
 			.attr("y", (d) => y(d.length))
-			.attr("height", (d) => y(0) - y(d.length));
+			.attr("height", (d) => y(0) - y(d.length))
+			.attr("opacity", 1);
 		foregroundNullGroup
 			?.select("rect")
 			.attr("y", y(nullCount))
@@ -233,12 +248,58 @@ export function CrossfilterHistogramPlot(
 	let node = svg.node();
 	assert(node, "Infallable");
 
+	// Function to find the closest rect to a given x-coordinate
+	function findClosestRect(x: number): SVGRectElement | null {
+		let closestRect: SVGRectElement | null = null;
+		let minDistance = Infinity;
+
+		foregroundBarGroup.selectAll("rect").each(function () {
+			const rect = d3.select(this);
+			const rectX = parseFloat(rect.attr("x"));
+			const rectWidth = parseFloat(rect.attr("width"));
+			const rectCenter = rectX + rectWidth / 2;
+			const distance = Math.abs(x - rectCenter);
+
+			if (distance < minDistance) {
+				minDistance = distance;
+				closestRect = this as SVGRectElement;
+			}
+		});
+
+		return closestRect;
+	}
+
 	node.addEventListener("mousemove", (event) => {
 		const relativeX = event.clientX - node.getBoundingClientRect().left;
-		hovered.value = clamp(x.invert(relativeX), xmin, xmax);
+		const hoveredX = x.invert(relativeX);
+		hovered.value = clamp(hoveredX, xmin, xmax);
+
+		const closestRect = findClosestRect(relativeX);
+
+		foregroundBarGroup.selectAll("rect")
+			.attr("opacity", function () {
+				return this === closestRect ? 1 : 0.3;
+			});
+
+		const hoveredValue = hovered.value;
+
+		const hoveredBin = hoveredValue !== undefined
+			? bins.find((bin) => hoveredValue >= bin.x0 && hoveredValue < bin.x1)
+			: undefined;
+		const hoveredValueCount = hoveredBin?.length;
+
+		countLabel.value =
+			hoveredValue !== undefined && hoveredValueCount !== undefined
+				? `${hoveredValueCount} row${hoveredValueCount === 1 ? "" : "s"} (${
+					percentFormatter(hoveredValueCount / total)
+				})`
+				: fieldType;
 	});
+
 	node.addEventListener("mouseleave", () => {
 		hovered.value = undefined;
+		foregroundBarGroup.selectAll("rect").attr("opacity", 1);
+		countLabel.value = fieldType;
 	});
 
 	render(bins, nullCount);

--- a/lib/utils/ValueCountsPlot.ts
+++ b/lib/utils/ValueCountsPlot.ts
@@ -2,7 +2,7 @@ import { effect, signal } from "@preact/signals-core";
 import type * as arrow from "apache-arrow";
 import * as d3 from "../deps/d3.ts";
 import { assert } from "./assert.ts";
-import { formatDataType } from "./formatting.ts";
+import { formatDataType, percentFormatter } from "./formatting.ts";
 
 type CountTableData = arrow.Table<{
 	key: arrow.Utf8;
@@ -97,7 +97,7 @@ export function ValueCountsPlot(
 		countLabel.value =
 			hoveredValue !== undefined && hoveredValueCount !== undefined
 				? `${hoveredValueCount} row${hoveredValueCount === 1 ? "" : "s"} (${
-					d3.format(".1%")(hoveredValueCount / total)
+					percentFormatter(hoveredValueCount / total)
 				})`
 				: fieldType;
 	});

--- a/lib/utils/formatting.ts
+++ b/lib/utils/formatting.ts
@@ -1,5 +1,6 @@
 import { Temporal } from "@js-temporal/polyfill";
 import * as arrow from "apache-arrow";
+import { format } from "d3-format";
 
 /**
  * A utility function to create a formatter for a given data type.
@@ -222,4 +223,19 @@ function durationFromTimeUnit(value: number | bigint, unit: arrow.TimeUnit) {
 		return Temporal.Duration.from({ nanoseconds: value });
 	}
 	throw new Error("Invalid TimeUnit");
+}
+
+/**
+ * Formats a number as a percentage string with varying precision based on the value's magnitude.
+ * @param {number} value - The value to be formatted as a percentage.
+ * @returns {string} A formatted percentage string.
+ */
+export function percentFormatter(value: number): string {
+	if (value >= 0.1) {
+		return format(".0%")(value);
+	} else if (value >= 0.01) {
+		return format(".1%")(value);
+	} else {
+		return format(".2%")(value);
+	}
 }

--- a/lib/utils/formatting.ts
+++ b/lib/utils/formatting.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@js-temporal/polyfill";
 import * as arrow from "apache-arrow";
-import { format } from "d3-format";
+import { format } from "d3";
 
 /**
  * A utility function to create a formatter for a given data type.


### PR DESCRIPTION
A little Friday night PR: adding hover effects to the histogram (see video).

- Add hover bar
- Show value counts/percents for the selected bin on hover

https://github.com/user-attachments/assets/ad946fd3-7640-4c73-bfc7-03248c6bbc95


In addition, I also created a `percentFormatter`, that formats percents in a cleaner manner, and added this to the `ValueCountsPlot` as well.

One note here, hovering over the histogram currently shows the x-axis value -- it may be more appropriate to show the actual bin interval (see image below, which is what Observable does). A different PR can add that in pretty easily given the current setup, if that's desired.

<img width="139" alt="Screenshot 2024-08-16 at 11 12 04 PM" src="https://github.com/user-attachments/assets/3087696c-34d7-4a48-b8b1-cda8ed90dab9">
