### PR TITLE
feat: Set histogram maxbins from 25 -> 18

### DIFF
--- a/lib/clients/Histogram.ts
+++ b/lib/clients/Histogram.ts
@@ -49,7 +49,7 @@ export class Histogram extends MosaicClient implements Mark {
 		super(options.filterBy);
 		this.#source = options;
 		// calls this.channelField internally
-		let bin = mplot.bin(options.column, { steps: 15 })(this, "x");
+		let bin = mplot.bin(options.column, { steps: 18 })(this, "x");
 		this.#select = { x1: bin.x1, x2: bin.x2, y: count() };
 		this.#interval = new mplot.Interval1D(this, {
 			channel: "x",

--- a/lib/clients/Histogram.ts
+++ b/lib/clients/Histogram.ts
@@ -49,7 +49,7 @@ export class Histogram extends MosaicClient implements Mark {
 		super(options.filterBy);
 		this.#source = options;
 		// calls this.channelField internally
-		let bin = mplot.bin(options.column)(this, "x");
+		let bin = mplot.bin(options.column, { steps: 15 })(this, "x");
 		this.#select = { x1: bin.x1, x2: bin.x2, y: count() };
 		this.#interval = new mplot.Interval1D(this, {
 			channel: "x",

--- a/lib/demo.ts
+++ b/lib/demo.ts
@@ -129,7 +129,7 @@ if (import.meta.hot) {
 	import.meta.hot.accept("./clients/DataTable.ts", async ({ datatable }) => {
 		coordinator.disconnect(dt);
 		dt = await datatable("df", {
-			coordinator: dt.coordinator,
+			coordinator,
 			height: 500,
 		});
 		table.replaceChildren();


### PR DESCRIPTION
The current auto-binning can be too granular and leads to pixel issues on some displays. This PR makes changes the maxbins from 25 -> 18, which I think is a nicer default for this size of small summary visualizations.

before:

<img width="382" alt="image" src="https://github.com/user-attachments/assets/45322833-da4b-4ac3-8c1d-a408890c69dc">


after:

<img width="317" alt="image" src="https://github.com/user-attachments/assets/36d73aed-124c-4ad1-9467-6cba973ef4d3">
