### PR TITLE
CLI: Support more platforms

### DIFF
--- a/cli/src/static/index.html
+++ b/cli/src/static/index.html
@@ -22,6 +22,9 @@
       }
     </style>
     <script type="module">
+      console.log('hello')
+    </script>
+    <script type="module">
       import { embed } from "/widget.js";
 
       let cliDt = await embed(datatable);
@@ -32,10 +35,11 @@
           headers: { "Content-Type": "text/plain" },
           body: sql,
         });
-        console.log(response.status);
+        console.log('response', response.status);
       });
     </script>
   <body>
+    Hello
     <div id="datatable"></div>
   </body>
 </html>


### PR DESCRIPTION
CLI doesn't work on Ubuntu. wry [examples](https://github.com/tauri-apps/wry/tree/dev/examples) work, so I compared code, and their examples include some platform-specific bits that I added to try to fix this.

It's an improvement: now pages load for me from my testing, but there is an error occurring somehow within the call to `embed(datatable)`; with no details in the console.

Interested in ideas to proceed. ~~Can there be some JS working in MacOS Webkit and not in WebkitGTK?~~

Note: The platform-specific changes made here will need to change for upgrades of wry, see notes of breaking changes in [changelog](https://github.com/tauri-apps/wry/blob/dev/CHANGELOG.md#0460) (examples diffs help me to identify these changes - rust newbie here - but interested to help out if I can as this tool and pattern is really neat!)