### PR TITLE
fix: Remove intersection observer

### DIFF
--- a/lib/clients/DataTable.ts
+++ b/lib/clients/DataTable.ts
@@ -551,12 +551,6 @@ function shouldGrayoutValue(value: string) {
 	);
 }
 
-function isTableColumnHeaderWithSvg(
-	node: unknown,
-): node is ReturnType<typeof thcol> {
-	return node instanceof HTMLTableCellElement && "vis" in node;
-}
-
 /**
  * A mosaic SQL expression for ascending order
  *

--- a/lib/clients/DataTable.ts
+++ b/lib/clients/DataTable.ts
@@ -265,21 +265,6 @@ export class DataTable extends MosaicClient {
 			<td style=${{ width: "99%", borderLeft: "none", borderRight: "none" }}></td>
 		</tr>`;
 
-		let observer = new IntersectionObserver((entries) => {
-			for (let entry of entries) {
-				if (!isTableColumnHeaderWithSvg(entry.target)) continue;
-				let vis = entry.target.vis;
-				if (!vis) continue;
-				if (entry.isIntersecting) {
-					this.coordinator.connect(vis);
-				} else {
-					this.coordinator?.disconnect(vis);
-				}
-			}
-		}, {
-			root: this.#tableRoot,
-		});
-
 		let cols = this.#meta.schema.fields.map((field) => {
 			let info = infos.find((c) => c.column === field.name);
 			assert(info, `No info for column ${field.name}`);
@@ -300,7 +285,7 @@ export class DataTable extends MosaicClient {
 				});
 			}
 			let th = thcol(field, this.#columnWidth, vis);
-			observer.observe(th);
+			this.coordinator.connect(vis);
 			return th;
 		});
 


### PR DESCRIPTION
We used a `MutationObserver` to dynamically connect and disconnect header summary clients to try to avoid dispatching queries that are outside the view. However, this lead to some rendering bugs that put the UI into a weird state.

For now, I am removing this premature optimization such that we can implement with a more efficient and correct solution later. It fixes some consistency issues in rendering, which I think should be the priority.
