### PR TITLE
Remove workaround for mosaic client updates (and flickering in UI)

### DIFF
--- a/lib/clients/ValueCounts.ts
+++ b/lib/clients/ValueCounts.ts
@@ -8,7 +8,6 @@ import {
 	column,
 	count,
 	type ExprNode,
-	type MaybeArray,
 	Query,
 	sql,
 	sum,
@@ -18,7 +17,6 @@ import { effect } from "@preact/signals-core";
 
 import { ValueCountsPlot } from "../utils/ValueCountsPlot.ts";
 import { assert } from "../utils/assert.ts";
-import { isFlechetteTable } from "../utils/guards.ts";
 
 interface UniqueValuesOptions {
 	/** The table to query. */
@@ -43,28 +41,6 @@ export class ValueCounts extends MosaicClient {
 		this.#table = options.table;
 		this.#column = options.field.name;
 		this.#field = options.field;
-
-		// FIXME: There is some issue with the mosaic client or the query we
-		// are using here. Updates to the Selection (`filterBy`) seem to be
-		// missed by the coordinator, and query/queryResult are not called
-		// by the coordinator when the filterBy is updated.
-		//
-		// Here we manually listen for the changes to filterBy and update this
-		// client internally. It _should_ go through the coordinator.
-		options.filterBy.addEventListener("value", async () => {
-			if (!this.#plot || !this.coordinator) {
-				return;
-			}
-			let filters = options.filterBy.predicate(this);
-			assert(
-				isExprNodeArray(filters),
-				`Filter is not expression array: ${filters}`,
-			);
-			let query = this.query(filters);
-			let data = await this.coordinator.query(query);
-			assert(isFlechetteTable(data), "Expected a flechette table.");
-			this.#plot.data.value = data;
-		});
 	}
 
 	override query(filter: Array<ExprNode> = []): Query {
@@ -129,10 +105,4 @@ export class ValueCounts extends MosaicClient {
 			node: () => this.#el,
 		};
 	}
-}
-
-function isExprNodeArray(
-	x: MaybeArray<string | boolean | undefined | ExprNode>,
-): x is Array<ExprNode> {
-	return Array.isArray(x) && x.every((y) => typeof y === "object");
 }


### PR DESCRIPTION
More code elimination!

The manual listener for `filterBy` changes is no longer needed with the latest mosaic and was causing flickering. The coordinator now properly handles `Selection` updates and triggers query/queryResult calls when `filterBy` is updated.