### PR TITLE
Fix stale cross-filter visuals on deselect

### DIFF
--- a/assets/logo-color.svg
+++ b/assets/logo-color.svg
@@ -6,8 +6,7 @@
 	viewBox="0 0 508.28 374.25"
 >
 	<defs>
-		<style>
-		.cls-1 {
+		<style>.cls-1 {
 			fill: #fe7f03;
 		}
 
@@ -21,8 +20,7 @@
 
 		.cls-3 {
 			fill: #fff;
-		}
-		</style>
+		}</style>
 	</defs>
 	<g id="Layer_1-2" data-name="Layer 1">
 		<path

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -6,8 +6,7 @@
 	viewBox="0 0 166.87 121.85"
 >
 	<defs>
-		<style>
-		.cls-1 {
+		<style>.cls-1 {
 			fill: #000;
 			stroke-width: 0px;
 		}
@@ -21,8 +20,7 @@
 			stroke: #000;
 			stroke-miterlimit: 10;
 			stroke-width: 6px;
-		}
-		</style>
+		}</style>
 	</defs>
 	<g id="Layer_1-2" data-name="Layer 1">
 		<g>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 				<input
 					type="file"
 					class="absolute w-full h-full opacity-0"
-					accept=".csv,.parquet,.tsv,.json"
+					accept=".csv, .parquet, .tsv, .json"
 				/>
 				<img src="./assets/logo-color.svg" class="h-20 w-20" />
 				<div id="message" class="text-center">

--- a/lib/clients/DataTable.ts
+++ b/lib/clients/DataTable.ts
@@ -254,6 +254,16 @@ export class DataTable extends MosaicClient {
 	}
 
 	override async prepare(): Promise<void> {
+		// Workaround for mosaic-core bug: PreAggregator doesn't clear its cache
+		// when a selection is cleared (predicate becomes null). This causes stale
+		// materialized view data to be served on deselect. We listen for selection
+		// updates and clear the cache when the active clause has no predicate.
+		this.filterBy?.addEventListener("value", () => {
+			if (this.filterBy?.clauses.active?.predicate == null) {
+				this.coordinator?.preaggregator.clear();
+			}
+		});
+
 		const infos = await queryFieldInfo(
 			this.coordinator!,
 			this.#columns.map((column_name) => ({

--- a/lib/clients/Histogram.ts
+++ b/lib/clients/Histogram.ts
@@ -121,6 +121,11 @@ export class Histogram extends MosaicClient implements Mark {
 		return this;
 	}
 
+	reset() {
+		this.#interval?.reset();
+		this.svg?.reset();
+	}
+
 	/* Required by the Mark interface */
 	type = "rectY";
 	/** Required by `mplot.bin` to get the field info. */

--- a/lib/utils/CrossfilterHistogramPlot.ts
+++ b/lib/utils/CrossfilterHistogramPlot.ts
@@ -45,6 +45,7 @@ export function CrossfilterHistogramPlot(
 ): SVGSVGElement & {
 	scale: (type: string) => Scale<number, number>;
 	update(bins: Array<Bin>, opts: { nullCount: number }): void;
+	reset(): void;
 } {
 	const fieldType = formatDataType(field.type);
 	const total = bins.reduce((sum, bin) => sum + bin.length, 0);


### PR DESCRIPTION
Mosaic's PreAggregator caches materialized views when a selection is first created but doesn't clear the cache when the selection is removed (active clause predicate becomes null). The cached preagg query returns data with different binning than the original client query, so column header visualizations render stale filtered bars after deselect.

This works around the upstream bug by listening for selection value events in DataTable and clearing the preaggregator cache when the active clause has no predicate. This preserves preaggregation during interactive brushing while ensuring a clean reset on deselect.

Also adds a `reset()` method to Histogram so the global Reset button properly clears the brush and re-renders the SVG.